### PR TITLE
Support string to date coercion

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -168,6 +168,30 @@ var validateBoolean = function(val, schema, callback, keyPath) {
 	
 };
 
+var validateDate = function(val, schema, callback, keyPath) {
+	
+	if (val) {
+		
+		if ('String' == val.constructor.name ) {
+			var date = new Date(val);
+			if ( ! isNaN(date.getDate()) )
+	 			return callback(null,date);
+
+			return callback(new ValidationError(keyPath, schema, 'Is not a valid Date string.'));	
+		}
+
+		if ('Date' != val.constructor.name) {
+			return callback(new ValidationError(keyPath, schema, 'Is not coerceable to a Date.'));
+		}
+		
+		return callback(null, val);
+		
+	}
+	
+	return callback(null, val);
+	
+};
+
 var validateCustom = function(obj, schema, callback, keyPath) {
 	
 	return schema.custom(obj, schema, function(err, validObj) {
@@ -202,6 +226,7 @@ var validateAny = function(obj, schema, callback, keyPath) {
 	if ('String' == schema.type.name) return validateString(obj, schema, callback, keyPath);
 	if ('Number' == schema.type.name) return validateNumber(obj, schema, callback, keyPath);
 	if ('Boolean' == schema.type.name) return validateBoolean(obj, schema, callback, keyPath);
+	if ('Date' == schema.type.name) return validateDate(obj, schema, callback, keyPath);
 	
 	throw new Error('Cannot validate schema of type ' + schema.type.name + '.');
 	

--- a/test/validate.js
+++ b/test/validate.js
@@ -243,6 +243,21 @@ describe('Validate', function() {
 				});
 			});
 		});
+		describe('[Date validators]', function() {
+			it ('should come back with error if input is not a Date', function(done) {
+				validate([], { type: Date }, function(err, validObj) {
+					expect(err).to.be.validationError;
+					done();
+				});
+			});
+			it ('should come back with no error and validObj set to a Date if input is string with an ISO date', function(done) {
+				validate('2014-10-19T02:24:42.395Z', { type: Date }, function(err, validObj) {
+					expect(err).to.be.null;
+					expect(validObj.getTime()).to.equal(new Date("2014-10-19T02:24:42.395Z").getTime());
+					done();
+				});
+			});
+		});
 		describe('[custom validators]', function() {
 			it ('should call function if custom is specified.', function(done) {
 				validate({}, {


### PR DESCRIPTION
Dates get serialized to JSON as ISO-8601 date strings such as `'2014-10-19T02:24:42.395Z'` which also can be passed directly to the `Date` constructor.  This makes it easy to support automatically coercing a date `String` back to a `Date` object when validation occurs.  I've also tested this with isvalid-express.js and it works great in my node app!
