### PR TITLE
No way to get a Co/Koa yieldable? That's a shame...

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ Usage: `isvalid.validate.param(schema)` validates `req.param`.
 
 > Remark: If validation fails `isvalid` will unset the validated content (eg. `req.body` will become `null` if body validation fails). This is to ensure that routes does not get called with invalid data, in case a validation error isn't correctly handled.
 
+## As a Co or Koa yieldable
+
+Just use the `co` exported property instead of the whole exported object.
+
+### Example
+
+    var isvalid = require('isvalid').co;
+
+    var queryValidator = {
+        k: {
+            type: String,
+            required: true,
+            match: /[A-Za-z0-9_ ]+/
+        }
+    };
+
+    app.use(function* (next) {
+        this.query = yield isvalid(this.query, queryValidator);
+        yield next;
+    });
+
 # How it Works
 
 **isvalid** is a comprehensive validation library - build for ease of use. Both as Connect or Express middleware - where it comes in really handy - or as stand alone.

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -430,3 +430,9 @@ module.exports = function(data, schema, fn, keyPath, options) {
 	return validateAny(data, schema, fn, keyPath, options);
 
 };
+
+module.exports.co = function (data, schema, keyPath, options) {
+	return function (fn) {
+		return module.exports(data, schema, fn, keyPath, options);
+	};
+}


### PR DESCRIPTION
I am planning to switch my code to [Koa](http://koajs.com/), which means replacing callback hell with generator coroutine flow. Currently, if I want to use isvalid in such a context I have to do like so:
```javascript
index.get("/", function* (next) {
    var coherentQuery = yield c => isValid(this.query, queryValidator, c);
   // do stuff with it...
    yield next;
});
```
After the edit, by replacing `require("isvalid")` with `require("isvalid").co` I can write instead:
```javascript
index.get("/", function* (next) {
    var coherentQuery = yield isValid(this.query, queryValidator);
   // do stuff with it...
    yield next;
});
```
It might seem trivial but, apart from the code looking cleaner, not everybody knows how to turn a node-style async function into a yieldable, nor is everybody comfortable with currying.