### PR TITLE
Check typeof schema.type before processing node

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -116,7 +116,8 @@ var formalizeAny = function(schema, fn, sync) {
 	// If schema is already formalized we just call back.
 	if (typeof schema._nonFormalizedSchema !== 'undefined') return fn(schema, false);
 
-	if (!schema.type && !schema.custom && !schema.equal) {
+	if (!(schema.type && (typeof schema.type === 'function' || schema.type instanceof Array)) &&
+			!schema.custom && !schema.equal) {
 		if ('Object' == utils.name(schema.constructor)) {
 			return formalizeObject({ type: Object, schema: schema }, schema, fn, sync);
 		}


### PR DESCRIPTION
Hey,
I needed to validate field named `type` and faced issue with it. This PR is how I solved it, perhaps you want to merge. There still will be conflicts with `custom` and `equals` fields, but it not so often used. 