### PR TITLE
:sparkles: support E notation for numbers

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -158,7 +158,7 @@ const validateString = async (data, schema, options, keyPath) => {
 
 const validateNumber = async (data, schema, options, keyPath) => {
 
-	if (typeof data === 'string' && /^-?[0-9]+(?:\.[0-9]+)?$/.test(data)) {
+	if (typeof data === 'string' && /^-?[0-9]+(?:\.[0-9]+)?(?:[eE]-?[0-9]+)?$/.test(data)) {
 		data = parseFloat(data);
 	}
 	

--- a/test/validate.js
+++ b/test/validate.js
@@ -317,8 +317,16 @@ describe('validate', function() {
 		it('should convert string values into numbers if string contains a negative number.', () => {
 			return expect(isvalid('-123.987', Number)).to.eventually.equal(-123.987);
 		});
+		it('should convert string values into numbers if string contains a E notation.', () => {
+			return expect(isvalid('5.8e-7', Number)).to.eventually.equal(5.8e-7);
+		});
 		it('should come back with error if string is supplied - but not a number.', () => {
 			return expect(isvalid('abc', Number))
+				.to.eventually.be.rejectedWith(ValidationError)
+				.and.to.have.property('validator', 'type');
+		});
+		it('should come back with error if wrong E notation is supplied - but not a number.', () => {
+			return expect(isvalid('12e', Number))
 				.to.eventually.be.rejectedWith(ValidationError)
 				.and.to.have.property('validator', 'type');
 		});


### PR DESCRIPTION
Since javascript switches to E notation for small numbers, they fail when you feed them to the validator. This PR ensures they are parsed correctly.